### PR TITLE
Better handling of the Scopes property.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.5.2</VersionPrefix>
+    <VersionPrefix>1.6.0-preview-4</VersionPrefix>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.6.0-preview-4</VersionPrefix>
+    <VersionPrefix>1.6.0</VersionPrefix>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/src/Stratiteq.Extensions.AspNetCore.Swagger/SwaggerExtensions.cs
+++ b/src/Stratiteq.Extensions.AspNetCore.Swagger/SwaggerExtensions.cs
@@ -35,6 +35,11 @@ namespace Stratiteq.Extensions.AspNetCore.Swagger
             swaggerUIOptions.OAuthScopeSeparator(" ");
         }
 
+        /// <summary>
+        /// Configure SwaggerGenOptions for oauth2 authentication.
+        /// </summary>
+        /// <param name="swaggerGenOptions">The SwaggerGenOptions instance to extend.</param>
+        /// <param name="azureADConfiguration">The configuration for authentication.</param>
         public static void ConfigureOauth2Authentication(this SwaggerGenOptions swaggerGenOptions, AzureADConfiguration azureADConfiguration)
         {
             ConfigureOauth2Authentication(
@@ -50,21 +55,17 @@ namespace Stratiteq.Extensions.AspNetCore.Swagger
         /// Configure SwaggerGenOptions for oauth2 authentication.
         /// </summary>
         /// <param name="swaggerGenOptions">The SwaggerGenOptions instance to extend.</param>
-        /// <param name="instance">The oauth2 endpoint.</param>
-        /// <param name="clientId">The ClientId for oauth2 endpoint.</param>
-        /// <param name="tenantId">The TenantId.</param>
-        /// <param name="appIdUri">The globally unique URI used to identify the web API. It is the prefix for scopes and in access tokens, it is the value of the audience claim. Also referred to as an identifier URI.</param>
-        /// <param name="requestedScope">The scope that the application requests.</param>
-        /// <exception cref="ArgumentNullException">Is thrown if any of the input parameters are null.</exception>
-        public static void ConfigureOauth2Authentication(
-            this SwaggerGenOptions swaggerGenOptions,
-            string? instance,
-            string? clientId,
-            string? tenantId,
-            string? appIdUri,
-            string requestedScope)
+        /// <param name="azureADConfiguration">The configuration for authentication.</param>
+        /// <param name="requestedScopes">The scopes that the application requests.</param>
+        public static void ConfigureOauth2Authentication(this SwaggerGenOptions swaggerGenOptions, AzureADConfiguration azureADConfiguration, string[] requestedScopes)
         {
-            ConfigureOauth2Authentication(swaggerGenOptions, instance, clientId, tenantId, appIdUri, new string[] { requestedScope });
+            ConfigureOauth2Authentication(
+                swaggerGenOptions,
+                azureADConfiguration.Instance,
+                azureADConfiguration.ClientId,
+                azureADConfiguration.TenantId,
+                azureADConfiguration.AppIdentifier,
+                requestedScopes);
         }
 
         /// <summary>
@@ -83,7 +84,7 @@ namespace Stratiteq.Extensions.AspNetCore.Swagger
             string? clientId,
             string? tenantId,
             string? appIdUri,
-            string?[] requestedScopes)
+            string[] requestedScopes)
         {
             if (string.IsNullOrEmpty(instance))
             {

--- a/src/Stratiteq.Extensions.Configuration/AzureADConfiguration.cs
+++ b/src/Stratiteq.Extensions.Configuration/AzureADConfiguration.cs
@@ -32,12 +32,12 @@ namespace Stratiteq.Extensions.Configuration
         {
         }
 
-        public AzureADConfiguration(string? appIdentifier, string? tenantId, string? clientId, string?[] scopes)
+        public AzureADConfiguration(string? appIdentifier, string? tenantId, string? clientId, string[]? scopes = null)
         {
             this.AppIdentifier = appIdentifier ?? throw new ArgumentNullException(nameof(appIdentifier));
             this.TenantId = tenantId ?? throw new ArgumentNullException(nameof(tenantId));
             this.ClientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
-            this.Scopes = scopes ?? throw new System.ArgumentNullException(nameof(scopes));
+            this.Scopes = scopes ?? new string[] { $"{appIdentifier}/.default" };
         }
 
         public AzureADConfiguration(AzureADConfiguration azureADConfiguration)
@@ -47,6 +47,14 @@ namespace Stratiteq.Extensions.Configuration
                 azureADConfiguration.ClientId,
                 azureADConfiguration.Scopes)
         {
+        }
+
+        public AzureADConfiguration(string appIdentifier, AzureADConfiguration azureADConfiguration)
+            : this(azureADConfiguration)
+        {
+            this.AppIdentifier = appIdentifier;
+            // The .default scope is a built-in scope for every application that refers to the static list of permissions configured on the application registration.
+            this.Scopes = new string[] { $"{appIdentifier}/.default" };
         }
 
         /// <summary>
@@ -68,8 +76,9 @@ namespace Stratiteq.Extensions.Configuration
 
         /// <summary>
         /// Gets the scopes the application requests.
+        /// If no scope/s are provided the default scope is used. The "/.default" scope is a built-in scope for every application that refers to the static list of permissions configured on the application registration.
         /// </summary>
-        public string?[] Scopes { get; internal set; } = default!;
+        public string[] Scopes { get; internal set; } = default!;
 
         /// <summary>
         /// Gets the tenant id of the Azure Active Directory (AAD) that hosts the application that is requesting access to another application.
@@ -86,18 +95,13 @@ namespace Stratiteq.Extensions.Configuration
 
         public virtual IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            if (this.Scopes == null || this.Scopes?.Length == 0)
-            {
-                yield return new ValidationResult(string.Format(MissingAppSettingTemplate, nameof(this.Scopes)));
-            }
-
             if (this.Scopes != null)
             {
                 foreach (var scope in this.Scopes)
                 {
-                    if (string.IsNullOrEmpty(scope))
+                    if (UriUtilities.GetValidUri(scope) == null)
                     {
-                        yield return new ValidationResult("Configuration must have 1 or more scopes which is non null", new string[] { nameof(this.Scopes) });
+                        yield return new ValidationResult("Configuration contains scopes but they are not in a valid form", new string[] { nameof(this.Scopes) });
                     }
                 }
             }

--- a/src/Stratiteq.Extensions.Configuration/AzureADConfiguration.cs
+++ b/src/Stratiteq.Extensions.Configuration/AzureADConfiguration.cs
@@ -32,7 +32,7 @@ namespace Stratiteq.Extensions.Configuration
         {
         }
 
-        public AzureADConfiguration(string? appIdentifier, string? tenantId, string? clientId, string[]? scopes = null)
+        public AzureADConfiguration(string? appIdentifier, string? tenantId, string? clientId, string[] scopes = null!)
         {
             this.AppIdentifier = appIdentifier ?? throw new ArgumentNullException(nameof(appIdentifier));
             this.TenantId = tenantId ?? throw new ArgumentNullException(nameof(tenantId));

--- a/src/Stratiteq.Extensions.Configuration/CertificateConfiguration.cs
+++ b/src/Stratiteq.Extensions.Configuration/CertificateConfiguration.cs
@@ -22,32 +22,27 @@ namespace Stratiteq.Extensions.Configuration
             this.CertificateSubjectName = configuration["CertificateSubjectName"];
         }
 
-        public CertificateConfiguration(string? certificateSubjectName, string? appIdentifier, string? tenantId, string? clientId, string?[] scopes)
+        public CertificateConfiguration(string? certificateSubjectName, string? appIdentifier, string? tenantId, string? clientId, string[] scopes)
             : base(appIdentifier, tenantId, clientId, scopes)
         {
             this.CertificateSubjectName = certificateSubjectName ?? throw new System.ArgumentNullException(nameof(certificateSubjectName));
         }
 
-        public CertificateConfiguration(string? certificateSubjectName, string? appIdentifier, AzureADConfiguration azureADConfiguration)
-            : this(certificateSubjectName, azureADConfiguration)
+        public CertificateConfiguration(string certificateSubjectName, AzureADConfiguration azureADConfiguration)
+            : base(azureADConfiguration)
         {
-            this.AppIdentifier = appIdentifier;
+            this.CertificateSubjectName = certificateSubjectName ?? throw new System.ArgumentNullException(nameof(certificateSubjectName));
         }
 
-        public CertificateConfiguration(string? certificateSubjectName, AzureADConfiguration? azureADConfiguration)
-            : this(
-                certificateSubjectName,
-                azureADConfiguration?.AppIdentifier,
-                azureADConfiguration?.TenantId,
-                azureADConfiguration?.ClientId,
-                azureADConfiguration?.Scopes!)
+        public CertificateConfiguration(string certificateSubjectName, string appIdentifier, AzureADConfiguration azureADConfiguration)
+            : base(appIdentifier, azureADConfiguration)
         {
+            this.CertificateSubjectName = certificateSubjectName ?? throw new System.ArgumentNullException(nameof(certificateSubjectName));
         }
 
-        public CertificateConfiguration(string appIdentifier, CertificateConfiguration? certificateConfiguration)
-            : this(certificateConfiguration)
+        public CertificateConfiguration(string appIdentifier, CertificateConfiguration certificateConfiguration)
+            : this(certificateConfiguration.CertificateSubjectName!, appIdentifier, certificateConfiguration)
         {
-            this.AppIdentifier = appIdentifier;
         }
 
         private CertificateConfiguration(CertificateConfiguration? certificateConfiguration)

--- a/src/Stratiteq.Extensions.Configuration/ConfigurationExtensions.cs
+++ b/src/Stratiteq.Extensions.Configuration/ConfigurationExtensions.cs
@@ -3,12 +3,32 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Configuration;
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace Stratiteq.Extensions.Configuration
 {
     public static class ConfigurationExtensions
     {
+        public static Uri GetValidUri(this IConfiguration configuration, string key)
+        {
+            var value = configuration.GetValidValue<string>(key);
+
+            if (!string.IsNullOrEmpty(value) && Uri.IsWellFormedUriString(value, UriKind.Absolute))
+            {
+                return new Uri(value);
+            }
+
+            throw new ValidationException("Uri is not well formed");
+        }
+
+        public static T GetValidValue<T>(this IConfiguration configuration, string key)
+        {
+            var value = configuration.GetValue<T>(key) ?? throw new ValidationException($"Configuration key: {key} that is required for the application to start is missing.");
+            Validator.ValidateObject(value, new ValidationContext(value), true);
+            return value;
+        }
+
         public static T GetValid<T>(this IConfiguration configuration)
         {
             var obj = configuration.Get<T>(c => c.BindNonPublicProperties = true);
@@ -21,6 +41,8 @@ namespace Stratiteq.Extensions.Configuration
         {
             var obj = configuration.Get<T>(c => c.BindNonPublicProperties = true);
             obj.AppIdentifier = appIdentifier;
+            // The .default scope is a built-in scope for every application that refers to the static list of permissions configured on the application registration.
+            obj.Scopes = new string[] { $"{appIdentifier}/.default" };
 
             Validator.ValidateObject(obj, new ValidationContext(obj), true);
             return obj;

--- a/src/Stratiteq.Extensions.Configuration/Stratiteq.Extensions.Configuration.csproj
+++ b/src/Stratiteq.Extensions.Configuration/Stratiteq.Extensions.Configuration.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Stratiteq.Extensions\Stratiteq.Extensions.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Stratiteq.Extensions/UriUtilities.cs
+++ b/src/Stratiteq.Extensions/UriUtilities.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Stratiteq Sweden AB. All rights reserved.
+//
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Stratiteq.Extensions
+{
+    public static class UriUtilities
+    {
+        public static Uri? GetValidUri(string? value)
+        {
+            if (!string.IsNullOrEmpty(value) && Uri.IsWellFormedUriString(value, UriKind.Absolute))
+            {
+                return new Uri(value);
+            }
+
+            return null;
+        }
+    }
+}

--- a/tests/Stratiteq.Extensions.Tests/ConfigurationExtensionsTests.cs
+++ b/tests/Stratiteq.Extensions.Tests/ConfigurationExtensionsTests.cs
@@ -33,6 +33,14 @@ namespace Stratiteq.Extensions.Tests
         }
 
         [Test]
+        public void Get_Valid_AzureADConfiguration_With_Default_Scopes()
+        {
+            var validConfiguration = this.configuration.GetSection("Configuration2").GetValid<AzureADConfiguration>();
+
+            Assert.IsNotNull(validConfiguration);
+        }
+
+        [Test]
         public void Get_Valid_CertificateConfiguration()
         {
             var validConfiguration = this.configuration.GetSection("CertificateConfiguration1").GetValid<CertificateConfiguration>();
@@ -53,13 +61,35 @@ namespace Stratiteq.Extensions.Tests
         }
 
         [Test]
+        public void Configuration_With_Invalid_AppIdentifier_Should_Fail()
+        {
+            Assert.Throws<ValidationException>(() => this.configuration.GetSection("InvalidConfiguration4").GetValidUri("AppIdentifier"));
+        }
+
+        [Test]
+        public void Configuration_With_Missing_Key_Should_Fail()
+        {
+            Assert.Throws<ValidationException>(() => this.configuration.GetSection("InvalidConfiguration4").GetValidValue<string>("TenantId"));
+        }
+
+        [Test]
         public void GetConfigurationWithAppIdentifier()
         {
             var validConfiguration =
-                this.configuration.GetSection("Configuration1").GetValid<AzureADConfiguration>("AppIdentifier");
+                this.configuration.GetSection("Configuration1").GetValid<AzureADConfiguration>("http://AppIdentifier");
 
             Assert.IsNotNull(validConfiguration);
-            Assert.AreEqual(validConfiguration.AppIdentifier, "AppIdentifier");
+            Assert.AreEqual(validConfiguration.AppIdentifier, "http://AppIdentifier");
+        }
+
+        [Test]
+        public void Configuration_With_Different_AppIdentifier_Should_Have_Default_Scope()
+        {
+            var validConfiguration =
+                this.configuration.GetSection("Configuration2").GetValid<AzureADConfiguration>("http://AppIdentifier");
+
+            Assert.IsNotNull(validConfiguration);
+            Assert.AreEqual(validConfiguration.Scopes[0], "http://AppIdentifier/.default");
         }
     }
 }

--- a/tests/Stratiteq.Extensions.Tests/ConfigurationTests.cs
+++ b/tests/Stratiteq.Extensions.Tests/ConfigurationTests.cs
@@ -42,8 +42,7 @@ namespace Stratiteq.Extensions.Configuration
             var azureADConfiguration = new AzureADConfiguration(
                 "TestAppIdentifier",
                 "TestTenantId",
-                "TestClientId",
-                new[] { "TestScope" });
+                "TestClientId");
 
             // Act
             var certificateConfiguration = new CertificateConfiguration("TestSubjectName", azureADConfiguration);
@@ -66,7 +65,7 @@ namespace Stratiteq.Extensions.Configuration
                 "TestAppIdentifier",
                 "TestTenantId",
                 "TestClientId",
-                new[] { "TestScope" });
+                new[] { "test://testscope" });
 
             Assert.DoesNotThrow(() => Validator.ValidateObject(certificateConfiguration, new ValidationContext(certificateConfiguration)));
         }

--- a/tests/Stratiteq.Extensions.Tests/appsettings.json
+++ b/tests/Stratiteq.Extensions.Tests/appsettings.json
@@ -12,9 +12,14 @@
     "TenantId": "09c1e417-f736-4ffc-bb68-3b17ff143092",
     "ClientId": "d3609ef8-2113-4f7b-99db-d53d3db75f46",
     "Scopes": [
-      "scope1",
-      "scope2"
+      "api://scope1",
+      "api://scope2"
     ]
+  },
+  "Configuration2": {
+    "AppIdentifier": "https://test.net",
+    "TenantId": "09c1e417-f736-4ffc-bb68-3b17ff143092",
+    "ClientId": "d3609ef8-2113-4f7b-99db-d53d3db75f46"
   },
   "CertificateConfiguration1": {
     "CertificateSubjectName": "SubjectName2",
@@ -23,8 +28,8 @@
     "TenantId": "09c1e417-f736-4ffc-bb68-3b17ff143092",
     "ClientId": "d3609ef8-2113-4f7b-99db-d53d3db75f46",
     "Scopes": [
-      "scope1",
-      "scope2"
+      "api://scope1",
+      "api://scope2"
     ]
   },
   "CosmosDbConfiguration1": {
@@ -41,7 +46,7 @@
     "ClientId": "d3609ef8-2113-4f7b-99db-d53d3db75f46",
     "Scopes": [
       "",
-      "Scope2"
+      "api://Scope2"
     ]
   },
   "InvalidConfiguration2": {
@@ -53,10 +58,14 @@
     ]
   },
   "InvalidConfiguration3": {
+    "AppIdentifier": "invalidString",
     "TenantId": "09c1e417-f736-4ffc-bb68-3b17ff143092",
     "ClientId": "d3609ef8-2113-4f7b-99db-d53d3db75f46",
     "Scopes": [
       ""
     ]
+  },
+  "InvalidConfiguration4": {
+    "AppIdentifier": "invalidUri"
   }
 }


### PR DESCRIPTION
Restructured constructors for CertificateConfiguration and AzureADConfiguration so they work create the scopes correctly when creating a configuration from json but with different AppIdentifiers.

Added some extension methods for creating Configurations from json.

Upping version to 1.6.0