### PR TITLE
Adds JsonProperty with directives for formatting

### DIFF
--- a/src/Stratiteq.Extensions.AspNetCore/ProblemDetailsWithErrorCode.cs
+++ b/src/Stratiteq.Extensions.AspNetCore/ProblemDetailsWithErrorCode.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.AspNetCore.Mvc;
 using System;
+using Newtonsoft.Json;
 
 namespace Stratiteq.Extensions.AspNetCore
 {
@@ -25,6 +26,7 @@ namespace Stratiteq.Extensions.AspNetCore
         /// <summary>
         /// Gets the unique code for identifying the specific error within this API.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "errorCode")]
         public string ErrorCode { get; }
 
         /// <summary>


### PR DESCRIPTION
## Bug fix: `ErrorCode` property is not properly formatted when serialized to JSON

### Cause of bug
JsonProperty attribute missing for ErrorCode to add serialization settings

### Solution
Add JsonProperty using same settings as parent ProblemDetails class