### PR TITLE
Bug: Null value should not be ignored

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.6.1</VersionPrefix>
+    <VersionPrefix>1.6.2</VersionPrefix>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.6.2</VersionPrefix>
+    <VersionPrefix>1.6.1</VersionPrefix>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/src/Stratiteq.Extensions.AspNetCore/ProblemDetailsWithErrorCode.cs
+++ b/src/Stratiteq.Extensions.AspNetCore/ProblemDetailsWithErrorCode.cs
@@ -4,7 +4,7 @@
 
 using Microsoft.AspNetCore.Mvc;
 using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Stratiteq.Extensions.AspNetCore
 {
@@ -26,7 +26,7 @@ namespace Stratiteq.Extensions.AspNetCore
         /// <summary>
         /// Gets the unique code for identifying the specific error within this API.
         /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "errorCode")]
+        [JsonPropertyName("errorCode")]
         public string ErrorCode { get; }
 
         /// <summary>

--- a/src/Stratiteq.Extensions.AspNetCore/Stratiteq.Extensions.AspNetCore.csproj
+++ b/src/Stratiteq.Extensions.AspNetCore/Stratiteq.Extensions.AspNetCore.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
## Cause
Declared wrong null value handling, not in compliance with base class

## Solution
Use `JsonPropertName` from System.Text.Json.Serialization and remove modifier for null value handling 